### PR TITLE
refactor: remove alert dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "folders"
   ],
   "dependencies": {
-    "alert": "^5.0.10",
     "alfy": "^0.12.2",
     "del": "^6.0.0",
     "dialog": "github:preethamvishy/dialog",


### PR DESCRIPTION
Hey @chrisspiegl,

The "alert" package was deprecated long time ago.
I've made a small update which removes the "alert" package dependency since it was not used. Could you please bump the version and push this change to npm? This way, your package won't be a dependent of the "alert" package anymore.

Cheers,
Patrick